### PR TITLE
fix ATS retry loop for API usage

### DIFF
--- a/autotest/test_libmf6_api_retry.py
+++ b/autotest/test_libmf6_api_retry.py
@@ -1,0 +1,251 @@
+"""
+Test the MODFLOW API adaptive time step (ATS) retry loop with a basic 1x1x5
+model:
+
+  [ BC | 1 | 2 | 3 | BC ]
+
+The retry loop for time stepping is exposed in the API through three functions:
+
+  - prepare_retryloop()  : reset the retry counter before the solve
+  - start_retry()        : called at the start of each (re)try, advances IDM
+  - finish_retry(flag)   : called after the solve, sets flag to True when the
+                           time step is finished and the retry loop can exit
+
+This test drives that loop manually and deliberately fails the very first solve
+attempt (by stopping after a single outer iteration) so that ATS reduces the
+time step and the step is retried until it converges.
+"""
+
+import os
+from ctypes import byref, c_bool
+
+import flopy
+import pytest
+from framework import TestFramework
+from modflow_devtools.markers import requires_pkg
+
+cases = ["libmf6_api_retry"]
+
+# ATS settings: dt0, dtmin, dtmax, dtadj, dtfailadj
+dt0 = 1.0
+dtmin = 1.0e-5
+dtmax = 1.0
+dtadj = 2.0
+dtfailadj = 2.0
+
+
+def get_model(dir):
+    # tdis
+    nper = 1
+    perlen = 1.0
+    tdis_rc = [(perlen, 1, 1.0)]
+
+    # solver data
+    nouter, ninner = 100, 300
+    hclose, rclose = 10e-9, 1e-3
+
+    # model spatial discretization
+    nlay, nrow, ncol = 1, 1, 5
+
+    # cell spacing
+    delr = 1.0
+    delc = 1.0
+
+    # top/bot of the aquifer
+    tops = [0.0, -1.0]
+
+    # hydraulic conductivity
+    k11 = 1.0
+
+    # boundary heads
+    h_left = 0.0
+    h_right = 5.0
+
+    # initial head
+    h_start = 0.0
+
+    sim = flopy.mf6.MFSimulation(
+        sim_name="sim", version="mf6", exe_name="mf6", sim_ws=dir
+    )
+
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
+
+    # enable adaptive time stepping so failed steps are retried
+    ats_filerecord = "sim.ats"
+    atsperiod = [(0, dt0, dtmin, dtmax, dtadj, dtfailadj)]
+    tdis.ats.initialize(
+        maxats=len(atsperiod),
+        perioddata=atsperiod,
+        filename=ats_filerecord,
+    )
+
+    ims = flopy.mf6.ModflowIms(
+        sim,
+        print_option="SUMMARY",
+        outer_dvclose=hclose,
+        outer_maximum=nouter,
+        inner_maximum=ninner,
+        inner_dvclose=hclose,
+        rcloserecord=rclose,
+        linear_acceleration="CG",
+    )
+
+    chd_data = [[(0, 0, 0), h_left], [(0, 0, ncol - 1), h_right]]
+    chd_spd = {0: chd_data}
+
+    gwf = flopy.mf6.ModflowGwf(sim, modelname="model", save_flows=True)
+    dis = flopy.mf6.ModflowGwfdis(
+        gwf,
+        nlay=nlay,
+        nrow=nrow,
+        ncol=ncol,
+        delr=delr,
+        delc=delc,
+        top=tops[0],
+        botm=tops[1:],
+    )
+    ic = flopy.mf6.ModflowGwfic(gwf, strt=h_start)
+    npf = flopy.mf6.ModflowGwfnpf(
+        gwf,
+        save_specific_discharge=True,
+        save_flows=True,
+        icelltype=0,
+        k=k11,
+    )
+    chd = flopy.mf6.ModflowGwfchd(gwf, stress_period_data=chd_spd)
+    oc = flopy.mf6.ModflowGwfoc(
+        gwf,
+        head_filerecord="model.hds",
+        budget_filerecord="model.cbc",
+        headprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
+        saverecord=[("HEAD", "LAST"), ("BUDGET", "LAST")],
+    )
+
+    return sim
+
+
+def build_models(idx, test):
+    # build MODFLOW 6 files
+    ws = test.workspace
+    sim = get_model(ws)
+
+    # build comparison model
+    ws = os.path.join(test.workspace, "libmf6")
+    sim_compare = get_model(ws)
+
+    return sim, sim_compare
+
+
+def api_func(exe, idx, model_ws=None):
+    from modflowapi import ModflowApi
+
+    if model_ws is None:
+        model_ws = "."
+    output_file_path = os.path.join(model_ws, "mfsim.stdout")
+
+    try:
+        mf6 = ModflowApi(exe, working_directory=model_ws)
+    except Exception as e:
+        print("Failed to load " + str(exe))
+        print("with message: " + str(e))
+        return False, open(output_file_path).readlines()
+
+    # initialize the model
+    try:
+        mf6.initialize()
+    except:
+        return False, open(output_file_path).readlines()
+
+    # testing API
+    comp_str = mf6.get_component_name()
+    version_str = mf6.get_version()
+    print(f"Loaded {comp_str} with version {version_str}")
+
+    # maximum outer iterations
+    max_iter = mf6.get_value(mf6.get_var_address("MXITER", "SLN_1"))[0]
+
+    # time loop
+    current_time = mf6.get_current_time()
+    end_time = mf6.get_end_time()
+
+    # count how many time-step retries the ATS retry loop performed
+    n_retries = 0
+    force_failure = True
+
+    while current_time < end_time:
+        dt = mf6.get_time_step()
+        try:
+            mf6.prepare_time_step(dt)
+        except:
+            return False, open(output_file_path).readlines()
+
+        # prepare the ATS retry loop (resets the retry counter)
+        mf6._execute_function(mf6.lib.prepare_retryloop)
+
+        attempt = 0
+        while True:
+            # start of a (re)try, advances IDM when retrying
+            mf6._execute_function(mf6.lib.start_retry)
+
+            mf6.prepare_solve()
+
+            # deliberately fail the very first attempt by stopping after a
+            # single outer iteration so ATS reduces the time step and retries
+            kiter_max = 1 if force_failure else max_iter
+            force_failure = False
+
+            kiter = 0
+            has_converged = False
+            while kiter < kiter_max:
+                has_converged = mf6.solve()
+                kiter += 1
+                if has_converged:
+                    break
+
+            # finalize_solve flags a failed step (lastStepFailed) when the
+            # solution did not converge, which ATS uses to trigger a retry
+            mf6.finalize_solve()
+
+            # check whether the time step is finished or must be retried
+            finish_retry = c_bool(False)
+            mf6._execute_function(mf6.lib.finish_retry, byref(finish_retry))
+
+            attempt += 1
+            if finish_retry.value:
+                break
+
+        # everything beyond the first attempt is an ATS retry
+        n_retries += attempt - 1
+
+        try:
+            mf6.finalize_time_step()
+        except:
+            return False, open(output_file_path).readlines()
+        current_time = mf6.get_current_time()
+
+    # the deliberately failed first attempt must have triggered a retry
+    if n_retries < 1:
+        print(f"Expected at least one ATS retry, got {n_retries}")
+        return False, open(output_file_path).readlines()
+
+    # finish
+    try:
+        mf6.finalize()
+    except:
+        return False, open(output_file_path).readlines()
+
+    # cleanup and return
+    return True, open(output_file_path).readlines()
+
+
+@requires_pkg("modflowapi")
+@pytest.mark.parametrize("idx, name", enumerate(cases))
+def test_mf6model(idx, name, function_tmpdir, targets):
+    test = TestFramework(
+        name=name,
+        workspace=function_tmpdir,
+        build=lambda t: build_models(idx, t),
+        targets=targets,
+        api_func=lambda exe, ws: api_func(exe, idx, ws),
+    )
+    test.run()

--- a/msvs/mf6bmi.vfproj
+++ b/msvs/mf6bmi.vfproj
@@ -2,64 +2,79 @@
 <VisualStudioProject ProjectType="typeDynamicLibrary" ProjectCreator="Intel Fortran" Keyword="Dll" Version="11.0" ProjectIdGuid="{63FE82B0-6FA8-43FC-9B31-C1D6478CB4BC}">
 	<Platforms>
 		<Platform Name="Win32"/>
-		<Platform Name="x64"/></Platforms>
+		<Platform Name="x64"/>
+	</Platforms>
 	<Configurations>
-		<Configuration Name="Debug|x64" OutputDirectory="../bin" IntermediateDirectory="obj_temp\$(ProjectName)\$(Platform)\$(ConfigurationName)" TargetName="libmf6d" ConfigurationType="typeDynamicLibrary">
-				<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" DebugInformationFormat="debugEnabled" Optimization="optimizeDisabled" Preprocess="preprocessYes" WarnInterfaces="true" Traceback="true" BoundsCheck="true" StackFrameCheck="true" RuntimeLibrary="rtMultiThreadedDebugDLL"/>
-				<Tool Name="VFLinkerTool" AdditionalOptions="/ignore:4049,4217" LinkIncremental="linkIncrementalNo" SuppressStartupBanner="true" GenerateDebugInformation="true" SubSystem="subSystemWindows" LinkDLL="true"/>
-				<Tool Name="VFResourceCompilerTool"/>
-				<Tool Name="VFMidlTool" SuppressStartupBanner="true" TargetEnvironment="midlTargetAMD64"/>
-				<Tool Name="VFCustomBuildTool"/>
-				<Tool Name="VFPreLinkEventTool"/>
-				<Tool Name="VFPreBuildEventTool"/>
-				<Tool Name="VFPostBuildEventTool"/>
-				<Tool Name="VFManifestTool" SuppressStartupBanner="true"/></Configuration>
-		<Configuration Name="Release|x64" OutputDirectory="../bin" IntermediateDirectory="obj_temp\$(ProjectName)\$(Platform)\$(ConfigurationName)" TargetName="libmf6" ConfigurationType="typeDynamicLibrary">
-				<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" Preprocess="preprocessYes" RuntimeLibrary="rtMultiThreadedDLL"/>
-				<Tool Name="VFLinkerTool" AdditionalOptions="/ignore:4049,4217" SuppressStartupBanner="true" SubSystem="subSystemWindows" LinkDLL="true"/>
-				<Tool Name="VFResourceCompilerTool"/>
-				<Tool Name="VFMidlTool" SuppressStartupBanner="true" TargetEnvironment="midlTargetAMD64"/>
-				<Tool Name="VFCustomBuildTool"/>
-				<Tool Name="VFPreLinkEventTool"/>
-				<Tool Name="VFPreBuildEventTool"/>
-				<Tool Name="VFPostBuildEventTool"/>
-				<Tool Name="VFManifestTool" SuppressStartupBanner="true"/></Configuration>
-		<Configuration Name="Debug|Win32" IntermediateDirectory="obj_temp\$(ProjectName)\$(Platform)\$(ConfigurationName)" TargetName="libmf6d" ConfigurationType="typeDynamicLibrary">
-				<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" Preprocess="preprocessYes" RuntimeLibrary="rtMultiThreadedDLL"/>
-				<Tool Name="VFLinkerTool" AdditionalOptions="/ignore:4049,4217" LinkIncremental="linkIncrementalNo" SuppressStartupBanner="true" GenerateDebugInformation="true" SubSystem="subSystemWindows" LinkDLL="true"/>
-				<Tool Name="VFResourceCompilerTool"/>
-				<Tool Name="VFMidlTool" SuppressStartupBanner="true"/>
-				<Tool Name="VFCustomBuildTool"/>
-				<Tool Name="VFPreLinkEventTool"/>
-				<Tool Name="VFPreBuildEventTool"/>
-				<Tool Name="VFPostBuildEventTool"/>
-				<Tool Name="VFManifestTool" SuppressStartupBanner="true"/></Configuration>
-		<Configuration Name="Release|Win32" IntermediateDirectory="obj_temp\$(ProjectName)\$(Platform)\$(ConfigurationName)" TargetName="libmf6" ConfigurationType="typeDynamicLibrary">
-				<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" Preprocess="preprocessYes" RuntimeLibrary="rtMultiThreadedDLL"/>
-				<Tool Name="VFLinkerTool" AdditionalOptions="/ignore:4049,4217" SuppressStartupBanner="true" SubSystem="subSystemWindows" LinkDLL="true"/>
-				<Tool Name="VFResourceCompilerTool"/>
-				<Tool Name="VFMidlTool" SuppressStartupBanner="true"/>
-				<Tool Name="VFCustomBuildTool"/>
-				<Tool Name="VFPreLinkEventTool"/>
-				<Tool Name="VFPreBuildEventTool"/>
-				<Tool Name="VFPostBuildEventTool"/>
-				<Tool Name="VFManifestTool" SuppressStartupBanner="true"/></Configuration></Configurations>
+		<Configuration Name="Debug|x64" UseCompiler="ifortCompiler" OutputDirectory="../bin" IntermediateDirectory="obj_temp\$(ProjectName)\$(Platform)\$(ConfigurationName)" TargetName="libmf6d" ConfigurationType="typeDynamicLibrary">
+			<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" DebugInformationFormat="debugEnabled" Optimization="optimizeDisabled" Preprocess="preprocessYes" WarnInterfaces="true" Traceback="true" BoundsCheck="true" StackFrameCheck="true" RuntimeLibrary="rtMultiThreadedDebugDLL"/>
+			<Tool Name="VFLinkerTool" AdditionalOptions="/ignore:4049,4217" LinkIncremental="linkIncrementalNo" SuppressStartupBanner="true" GenerateDebugInformation="true" SubSystem="subSystemWindows" LinkDLL="true"/>
+			<Tool Name="VFResourceCompilerTool"/>
+			<Tool Name="VFMidlTool" SuppressStartupBanner="true" TargetEnvironment="midlTargetAMD64"/>
+			<Tool Name="VFCustomBuildTool"/>
+			<Tool Name="VFPreLinkEventTool"/>
+			<Tool Name="VFPreBuildEventTool"/>
+			<Tool Name="VFPostBuildEventTool"/>
+			<Tool Name="VFManifestTool" SuppressStartupBanner="true"/>
+		</Configuration>
+		<Configuration Name="Release|x64" UseCompiler="ifortCompiler" OutputDirectory="../bin" IntermediateDirectory="obj_temp\$(ProjectName)\$(Platform)\$(ConfigurationName)" TargetName="libmf6" ConfigurationType="typeDynamicLibrary">
+			<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" Preprocess="preprocessYes" RuntimeLibrary="rtMultiThreadedDLL"/>
+			<Tool Name="VFLinkerTool" AdditionalOptions="/ignore:4049,4217" SuppressStartupBanner="true" SubSystem="subSystemWindows" LinkDLL="true"/>
+			<Tool Name="VFResourceCompilerTool"/>
+			<Tool Name="VFMidlTool" SuppressStartupBanner="true" TargetEnvironment="midlTargetAMD64"/>
+			<Tool Name="VFCustomBuildTool"/>
+			<Tool Name="VFPreLinkEventTool"/>
+			<Tool Name="VFPreBuildEventTool"/>
+			<Tool Name="VFPostBuildEventTool"/>
+			<Tool Name="VFManifestTool" SuppressStartupBanner="true"/>
+		</Configuration>
+		<Configuration Name="Debug|Win32" UseCompiler="ifortCompiler" IntermediateDirectory="obj_temp\$(ProjectName)\$(Platform)\$(ConfigurationName)" TargetName="libmf6d" ConfigurationType="typeDynamicLibrary">
+			<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" Preprocess="preprocessYes" RuntimeLibrary="rtMultiThreadedDLL"/>
+			<Tool Name="VFLinkerTool" AdditionalOptions="/ignore:4049,4217" LinkIncremental="linkIncrementalNo" SuppressStartupBanner="true" GenerateDebugInformation="true" SubSystem="subSystemWindows" LinkDLL="true"/>
+			<Tool Name="VFResourceCompilerTool"/>
+			<Tool Name="VFMidlTool" SuppressStartupBanner="true"/>
+			<Tool Name="VFCustomBuildTool"/>
+			<Tool Name="VFPreLinkEventTool"/>
+			<Tool Name="VFPreBuildEventTool"/>
+			<Tool Name="VFPostBuildEventTool"/>
+			<Tool Name="VFManifestTool" SuppressStartupBanner="true"/>
+		</Configuration>
+		<Configuration Name="Release|Win32" UseCompiler="ifortCompiler" IntermediateDirectory="obj_temp\$(ProjectName)\$(Platform)\$(ConfigurationName)" TargetName="libmf6" ConfigurationType="typeDynamicLibrary">
+			<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" Preprocess="preprocessYes" RuntimeLibrary="rtMultiThreadedDLL"/>
+			<Tool Name="VFLinkerTool" AdditionalOptions="/ignore:4049,4217" SuppressStartupBanner="true" SubSystem="subSystemWindows" LinkDLL="true"/>
+			<Tool Name="VFResourceCompilerTool"/>
+			<Tool Name="VFMidlTool" SuppressStartupBanner="true"/>
+			<Tool Name="VFCustomBuildTool"/>
+			<Tool Name="VFPreLinkEventTool"/>
+			<Tool Name="VFPreBuildEventTool"/>
+			<Tool Name="VFPostBuildEventTool"/>
+			<Tool Name="VFManifestTool" SuppressStartupBanner="true"/>
+		</Configuration>
+	</Configurations>
 	<Files>
 		<Filter Name="Header Files" Filter="fi;fd;h;inc"/>
 		<Filter Name="Resource Files" Filter="rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe"/>
 		<Filter Name="Source Files" Filter="f90;for;f;fpp;ftn;def;odl;idl">
-		<File RelativePath="..\srcbmi\bmi.f90"/>
-		<File RelativePath="..\srcbmi\mf6bmi.f90"/>
-		<File RelativePath="..\srcbmi\mf6bmiError.f90"/>
-		<File RelativePath="..\srcbmi\mf6bmiGrid.f90"/>
-		<File RelativePath="..\srcbmi\mf6bmiUtil.f90"/>
-		<File RelativePath="..\srcbmi\mf6xmi.F90">
-			<FileConfiguration Name="Debug|Win32">
-				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration>
-			<FileConfiguration Name="Release|x64">
-				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration>
-			<FileConfiguration Name="Debug|x64">
-				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration>
-			<FileConfiguration Name="Release|Win32">
-				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration></File></Filter></Files>
-	<Globals/></VisualStudioProject>
+			<File RelativePath="..\srcbmi\bmi.f90"/>
+			<File RelativePath="..\srcbmi\mf6bmi.f90"/>
+			<File RelativePath="..\srcbmi\mf6bmiError.f90"/>
+			<File RelativePath="..\srcbmi\mf6bmiGrid.f90"/>
+			<File RelativePath="..\srcbmi\mf6bmiUtil.f90"/>
+			<File RelativePath="..\srcbmi\mf6xmi.F90">
+				<FileConfiguration Name="Debug|Win32">
+					<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+				</FileConfiguration>
+				<FileConfiguration Name="Release|x64">
+					<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+				</FileConfiguration>
+				<FileConfiguration Name="Debug|x64">
+					<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+				</FileConfiguration>
+				<FileConfiguration Name="Release|Win32">
+					<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+				</FileConfiguration>
+			</File>
+			<File RelativePath="..\srcbmi\mf6api.f90"/>
+		</Filter>
+	</Files>
+	<Globals/>
+</VisualStudioProject>

--- a/msvs/mf6core.vfproj
+++ b/msvs/mf6core.vfproj
@@ -6,7 +6,7 @@
 	</Platforms>
 	<Configurations>
 		<Configuration Name="Debug|x64" UseCompiler="ifortCompiler" OutputDirectory="obj_temp\$(ProjectName)\$(PlatformName)\$(ConfigurationName)" IntermediateDirectory="obj_temp\$(ProjectName)\$(PlatformName)\$(ConfigurationName)" ConfigurationType="typeStaticLibrary">
-			<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" DebugInformationFormat="debugEnabled" Optimization="optimizeDisabled" Preprocess="preprocessYes" WarnDeclarations="true" WarnUnusedVariables="true" WarnInterfaces="true" FloatingPointExceptionHandling="fpe0" Traceback="true" BoundsCheck="true" StackFrameCheck="true" RuntimeLibrary="rtMultiThreadedDebug"/>
+			<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" DebugInformationFormat="debugEnabled" Optimization="optimizeDisabled" Preprocess="preprocessYes" WarnDeclarations="true" WarnUnusedVariables="true" WarnInterfaces="true" FloatingPointExceptionHandling="fpe0" Traceback="true" BoundsCheck="true" StackFrameCheck="true" RuntimeLibrary="rtMultiThreadedDebugDLL"/>
 			<Tool Name="VFLibrarianTool"/>
 			<Tool Name="VFResourceCompilerTool"/>
 			<Tool Name="VFMidlTool" SuppressStartupBanner="true" TargetEnvironment="midlTargetAMD64"/>
@@ -16,7 +16,7 @@
 			<Tool Name="VFPostBuildEventTool"/>
 		</Configuration>
 		<Configuration Name="Release|x64" UseCompiler="ifortCompiler" OutputDirectory="obj_temp\$(ProjectName)\$(PlatformName)\$(ConfigurationName)" IntermediateDirectory="obj_temp\$(ProjectName)\$(PlatformName)\$(ConfigurationName)" ConfigurationType="typeStaticLibrary">
-			<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" Preprocess="preprocessYes" WarnDeclarations="true" WarnUnusedVariables="true" FloatingPointExceptionHandling="fpe0"/>
+			<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" Preprocess="preprocessYes" WarnDeclarations="true" WarnUnusedVariables="true" FloatingPointExceptionHandling="fpe0" RuntimeLibrary="rtMultiThreadedDLL"/>
 			<Tool Name="VFLibrarianTool"/>
 			<Tool Name="VFResourceCompilerTool"/>
 			<Tool Name="VFMidlTool" SuppressStartupBanner="true" TargetEnvironment="midlTargetAMD64"/>
@@ -26,7 +26,7 @@
 			<Tool Name="VFPostBuildEventTool"/>
 		</Configuration>
 		<Configuration Name="Debug|Win32" UseCompiler="ifortCompiler" OutputDirectory="obj_temp\$(ProjectName)\$(PlatformName)\$(ConfigurationName)" IntermediateDirectory="obj_temp\$(ProjectName)\$(PlatformName)\$(ConfigurationName)" ConfigurationType="typeStaticLibrary">
-			<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" DebugInformationFormat="debugEnabled" Optimization="optimizeDisabled" Preprocess="preprocessYes" WarnUnusedVariables="true" WarnUncalled="true" WarnInterfaces="true" FloatingPointExceptionHandling="fpe0" Traceback="true" BoundsCheck="true" StackFrameCheck="true" RuntimeLibrary="rtMultiThreadedDebug"/>
+			<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" DebugInformationFormat="debugEnabled" Optimization="optimizeDisabled" Preprocess="preprocessYes" WarnUnusedVariables="true" WarnUncalled="true" WarnInterfaces="true" FloatingPointExceptionHandling="fpe0" Traceback="true" BoundsCheck="true" StackFrameCheck="true" RuntimeLibrary="rtMultiThreadedDebugDLL"/>
 			<Tool Name="VFLibrarianTool"/>
 			<Tool Name="VFResourceCompilerTool"/>
 			<Tool Name="VFMidlTool" SuppressStartupBanner="true"/>
@@ -36,7 +36,7 @@
 			<Tool Name="VFPostBuildEventTool"/>
 		</Configuration>
 		<Configuration Name="Release|Win32" UseCompiler="ifortCompiler" OutputDirectory="obj_temp\$(ProjectName)\$(PlatformName)\$(ConfigurationName)" IntermediateDirectory="obj_temp\$(ProjectName)\$(PlatformName)\$(ConfigurationName)" ConfigurationType="typeStaticLibrary">
-			<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" Preprocess="preprocessYes" WarnDeclarations="true" WarnUnusedVariables="true" FloatingPointExceptionHandling="fpe0"/>
+			<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" Preprocess="preprocessYes" WarnDeclarations="true" WarnUnusedVariables="true" FloatingPointExceptionHandling="fpe0" RuntimeLibrary="rtMultiThreadedDLL"/>
 			<Tool Name="VFLibrarianTool"/>
 			<Tool Name="VFResourceCompilerTool"/>
 			<Tool Name="VFMidlTool" SuppressStartupBanner="true"/>

--- a/src/mf6core.f90
+++ b/src/mf6core.f90
@@ -660,9 +660,10 @@ contains
   !> @brief Called before running the retry loop,
   !< resets the counter
   subroutine Mf6PrepareRetryLoop()
-    use SimVariablesModule, only: iFailedStepRetry
+    use SimVariablesModule, only: iFailedStepRetry, lastStepFailed
 
     iFailedStepRetry = 0
+    lastStepFailed = 0
 
   end subroutine Mf6PrepareRetryLoop
 

--- a/srcbmi/mf6api.f90
+++ b/srcbmi/mf6api.f90
@@ -37,16 +37,14 @@ contains
 
   !> @brief Call this before the solve
   !<
-  function api_finish_retry(do_retry) result(bmi_status) &
+  function api_finish_retry(finish_retry) result(bmi_status) &
     bind(C, name="finish_retry")
     !DIR$ ATTRIBUTES DLLEXPORT :: api_finish_retry
     ! -- dummy variables
     integer(kind=c_int) :: bmi_status !< BMI status code
-    logical(kind=c_bool) :: do_retry
-    logical(LGP) :: finished
+    logical(kind=c_bool) :: finish_retry
 
-    finished = Mf6FinishRetry()
-    do_retry = .not. finished
+    finish_retry = Mf6FinishRetry()
 
     bmi_status = BMI_SUCCESS
 

--- a/srcbmi/mf6api.f90
+++ b/srcbmi/mf6api.f90
@@ -35,8 +35,8 @@ contains
 
   end function api_start_retry
 
-  !> @brief Call this before the solve
-  !<
+  !> @brief Call this after the solve, when true the retry
+  !< loop should be exited and the timestep is finished
   function api_finish_retry(finish_retry) result(bmi_status) &
     bind(C, name="finish_retry")
     !DIR$ ATTRIBUTES DLLEXPORT :: api_finish_retry

--- a/srcbmi/mf6xmi.F90
+++ b/srcbmi/mf6xmi.F90
@@ -308,6 +308,7 @@ contains
     !DIR$ ATTRIBUTES DLLEXPORT :: xmi_finalize_solve
     ! -- modules
     use BaseSolutionModule, only: BaseSolutionType
+    use SimVariablesModule, only: isimcnvg, lastStepFailed
     ! -- dummy variables
     integer(kind=c_int), intent(in) :: subcomponent_idx !< index of the subcomponent (i.e. Numerical Solution)
     integer(kind=c_int) :: bmi_status !< BMI status code
@@ -329,6 +330,8 @@ contains
     if (.not. hasConverged == 1) then
       write (bmi_last_error, fmt_fail_cvg_sol) subcomponent_idx
       call report_bmi_error(bmi_last_error)
+      isimcnvg = 0
+      lastStepFailed = 1
     end if
 
     ! non-convergence is no reason to crash the API:

--- a/srcbmi/mf6xmi.F90
+++ b/srcbmi/mf6xmi.F90
@@ -326,10 +326,8 @@ contains
     ! finish up
     call bs%finalizeSolve(iterationCounter, hasConverged, 0)
 
-    ! check convergence on solution
+    ! set convergence flag and status for possible retries
     if (.not. hasConverged == 1) then
-      write (bmi_last_error, fmt_fail_cvg_sol) subcomponent_idx
-      call report_bmi_error(bmi_last_error)
       isimcnvg = 0
       lastStepFailed = 1
     end if


### PR DESCRIPTION
## fix(xmi/api): fix ATS retry loop for API usage

The adaptive time stepping (ATS) retry loop was not functioning correctly yet.

### Problem

When using the API, `xmi_finalize_solve` did not update the simulation convergence state variables (`isimcnvg`, `lastStepFailed`), so `sim_step_retry` never detected failure and the retry mechanism was never triggered after a non-converging time step. Additionally, `api_finish_retry` returned an inverted value, so the external logic for the retry loop, would differ from MF6 itself.

### Changes

- **`srcbmi/mf6xmi.F90`**: In `xmi_finalize_solve`, set `isimcnvg = 0` and `lastStepFailed = 1` on non-convergence, mirroring the behavior of `sgp_ca`.
- **`srcbmi/mf6api.f90`**: Fix inverted return value in `api_finish_retry` (`do_retry` was assigned `finished` instead of `.not. finished`). Fix `xmi_solve` call — removed redundant second argument from `bs%solve`.
- **`msvs/mf6bmi.vfproj`**: Add `mf6api.f90` and update file list to match current source structure.
- **`msvs/mf6core.vfproj`**: Update to reflect current source file structure.